### PR TITLE
Parts bidirectionality and refactor

### DIFF
--- a/vue/components/organisms/ripe-configurator/ripe-configurator.vue
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.vue
@@ -351,6 +351,11 @@ export const RipeConfigurator = {
     mounted: async function() {
         await this.setupRipe();
 
+        // saves the model parts after the RIPE configuration so that
+        // possible changes due to restrictions can be communicated
+        // to the parent component
+        this.partsData = Object.assign({}, this.ripeData.parts);
+
         this.configurator = this.ripeData.bindConfigurator(this.$refs.configurator, {
             view: this.frameData ? this.frameData.split("-")[0] : null,
             position: this.frameData ? this.frameData.split("-")[1] : null,

--- a/vue/components/organisms/ripe-configurator/ripe-configurator.vue
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.vue
@@ -367,6 +367,11 @@ export const RipeConfigurator = {
             this.selectedPartData = part;
         });
 
+        this.ripeData.bind("parts", parts => {
+            if (this.equalParts(parts, this.partsData)) return;
+            this.partsData = parts;
+        });
+
         this.configurator.bind("changed_frame", frame => {
             this.frameData = frame;
         });
@@ -380,10 +385,6 @@ export const RipeConfigurator = {
         this.configurator.bind("highlighted_part", part => {
             if (this.highlightedPartData === part) return;
             this.highlightedPartData = part;
-        });
-
-        this.ripeData.bind("parts", parts => {
-            this.partsData = parts;
         });
 
         this.resize(this.size);

--- a/vue/components/organisms/ripe-configurator/ripe-configurator.vue
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.vue
@@ -207,7 +207,8 @@ export const RipeConfigurator = {
              */
             highlightedPartData: this.highlightedPart,
             /**
-             * Parts of the model.
+             * Parts of the model to be used for the internal sync
+             * operation.
              */
             partsData: this.parts,
             /**

--- a/vue/components/organisms/ripe-configurator/ripe-configurator.vue
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.vue
@@ -59,7 +59,6 @@
 </style>
 
 <script>
-import { Ripe, ripe } from "ripe-sdk";
 import { ripe } from "ripe-sdk";
 import { logicMixin } from "../../../mixins";
 import "ripe-sdk/src/css/ripe.css";
@@ -385,42 +384,6 @@ export const RipeConfigurator = {
         this.resize(this.size);
     },
     methods: {
-        /**
-         * Initializes RIPE instance if it does not exists and
-         * configures it with the given brand, model, version
-         * and parts. If a RIPE instance is provided, it will
-         * be used without further configuration.
-         */
-        async setupRipe() {
-            if (!this.ripeData) {
-                this.ripeData = new Ripe();
-            }
-
-            await this.configRipe();
-
-            // in case the global RIPE instance is not set then
-            // updates it with the current one
-            if (!global.ripe) {
-                global.ripe = this.ripeData;
-            }
-        },
-        /**
-         * Configures the RIPE instance with the given brand,
-         * model, version and parts.
-         */
-        async configRipe() {
-            this.loading = true;
-
-            try {
-                await this.ripeData.config(this.brand, this.model, {
-                    version: this.version,
-                    parts: this.partsData
-                });
-            } catch (error) {
-                this.loading = false;
-                throw error;
-            }
-        },
         /**
          * Re-sizes the configurator according to the current
          * available container size (defined by parent).

--- a/vue/components/organisms/ripe-configurator/ripe-configurator.vue
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.vue
@@ -60,6 +60,8 @@
 
 <script>
 import { Ripe, ripe } from "ripe-sdk";
+import { ripe } from "ripe-sdk";
+import { logicMixin } from "../../../mixins";
 import "ripe-sdk/src/css/ripe.css";
 
 /**
@@ -68,6 +70,7 @@ import "ripe-sdk/src/css/ripe.css";
  */
 export const RipeConfigurator = {
     name: "ripe-configurator",
+    mixins: [logicMixin],
     props: {
         /**
          * The brand of the model.
@@ -217,9 +220,16 @@ export const RipeConfigurator = {
     },
     watch: {
         parts: {
-            handler: async function(value) {
+            handler: async function(value, previous) {
+                if (this.equalParts(value, previous)) return;
+
                 this.partsData = value;
                 await this.configRipe();
+            }
+        },
+        partsData: {
+            handler: function(value) {
+                this.$emit("update:parts", value);
             }
         },
         frame: {
@@ -302,9 +312,6 @@ export const RipeConfigurator = {
         },
         configProps: {
             handler: async function(value) {
-                // delete already defined parts when changing model,
-                // so that no customization errors occur
-                this.partsData = null;
                 await this.configRipe();
             }
         },
@@ -369,6 +376,10 @@ export const RipeConfigurator = {
         this.configurator.bind("highlighted_part", part => {
             if (this.highlightedPartData === part) return;
             this.highlightedPartData = part;
+        });
+
+        this.ripeData.bind("parts", parts => {
+            this.partsData = parts;
         });
 
         this.resize(this.size);

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -231,6 +231,11 @@ export const RipeImage = {
     mounted: async function() {
         await this.setupRipe();
 
+        // saves the model parts after the RIPE configuration so that
+        // possible changes due to restrictions can be communicated
+        // to the parent component
+        this.partsData = Object.assign({}, this.ripeData.parts);
+
         this.ripeData.bind("parts", parts => {
             this.partsData = parts;
         });

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -142,7 +142,8 @@ export const RipeImage = {
              */
             loading: true,
             /**
-             * Parts of the model.
+             * Parts of the model to be used for the internal sync
+             * operation.
              */
             partsData: this.parts,
             /**

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -10,7 +10,6 @@
 </style>
 
 <script>
-import { Ripe } from "ripe-sdk";
 import { logicMixin } from "../../../mixins";
 
 /**
@@ -244,39 +243,6 @@ export const RipeImage = {
         this.image.update(this.state);
     },
     methods: {
-        /**
-         * Configures the RIPE instance with the given brand,
-         * model, version and parts.
-         */
-        async configRipe() {
-            this.loading = true;
-            try {
-                await this.ripeData.config(this.brand, this.model, {
-                    version: this.version,
-                    parts: this.parts,
-                    safe: true
-                });
-            } catch (error) {
-                this.loading = false;
-                throw error;
-            }
-        },
-        /**
-         * Initializes RIPE instance if it does not exists and
-         * configures it with the given brand, model, version
-         * and parts. If a RIPE instance is provided, it will
-         * be used without further configuration.
-         */
-        async setupRipe() {
-            if (!this.ripeData) {
-                this.ripeData = new Ripe();
-            }
-
-            await this.configRipe();
-
-            if (global.ripe) return;
-            global.ripe = this.ripeData;
-        },
         onLoaded() {
             this.loading = false;
         }

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -231,6 +231,10 @@ export const RipeImage = {
     mounted: async function() {
         await this.setupRipe();
 
+        this.ripeData.bind("parts", parts => {
+            this.partsData = parts;
+        });
+
         this.image = this.ripeData.bindImage(this.$refs.image, {
             frame: this.frame,
             size: this.size || undefined,

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -11,6 +11,7 @@
 
 <script>
 import { Ripe } from "ripe-sdk";
+import { logicMixin } from "../../../mixins";
 
 /**
  * The component that contains the RIPE SDK's image,
@@ -18,6 +19,7 @@ import { Ripe } from "ripe-sdk";
  */
 export const RipeImage = {
     name: "ripe-image",
+    mixins: [logicMixin],
     props: {
         /**
          * The brand of the model to be rendered into
@@ -141,6 +143,10 @@ export const RipeImage = {
              */
             loading: true,
             /**
+             * Parts of the model.
+             */
+            partsData: this.parts,
+            /**
              * RIPE instance, which can be later initialized
              * if the given prop is not defined.
              */
@@ -148,6 +154,19 @@ export const RipeImage = {
         };
     },
     watch: {
+        parts: {
+            handler: async function(value, previous) {
+                if (this.equalParts(value, previous)) return;
+
+                this.partsData = value;
+                await this.configRipe();
+            }
+        },
+        partsData: {
+            handler: function(value) {
+                this.$emit("update:parts", value);
+            }
+        },
         frame: {
             handler: function(value) {
                 this.loading = true;

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -237,6 +237,7 @@ export const RipeImage = {
         this.partsData = Object.assign({}, this.ripeData.parts);
 
         this.ripeData.bind("parts", parts => {
+            if (this.equalParts(parts, this.partsData)) return;
             this.partsData = parts;
         });
 

--- a/vue/components/organisms/ripe-pickers/ripe-pickers.vue
+++ b/vue/components/organisms/ripe-pickers/ripe-pickers.vue
@@ -65,7 +65,7 @@
 
 <script>
 /**
- * The component that contains the RIPE SDK's image,
+ * The component that contains the RIPE's pickers,
  * for the static render of compositions.
  */
 export const RipePickers = {

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -81,7 +81,8 @@ export const RipePrice = {
              */
             loading: true,
             /**
-             * Parts of the model.
+             * Parts of the model to be used for the internal sync
+             * operation.
              */
             partsData: this.parts,
             /**

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -149,6 +149,7 @@ export const RipePrice = {
         this.partsData = Object.assign({}, this.ripeData.parts);
 
         this.ripeData.bind("parts", parts => {
+            if (this.equalParts(parts, this.partsData)) return;
             this.partsData = parts;
         });
 

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -143,6 +143,11 @@ export const RipePrice = {
     created: async function() {
         await this.setupRipe();
 
+        // saves the model parts after the RIPE configuration so that
+        // possible changes due to restrictions can be communicated
+        // to the parent component
+        this.partsData = Object.assign({}, this.ripeData.parts);
+
         this.ripeData.bind("parts", parts => {
             this.partsData = parts;
         });

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -7,8 +7,6 @@
 <style scoped></style>
 
 <script>
-import { Ripe } from "ripe-sdk";
-import { moneyMixin } from "../../../mixins";
 import { logicMixin, moneyMixin } from "../../../mixins";
 
 /**
@@ -17,7 +15,6 @@ import { logicMixin, moneyMixin } from "../../../mixins";
  */
 export const RipePrice = {
     name: "ripe-price",
-    mixins: [moneyMixin],
     mixins: [logicMixin, moneyMixin],
     props: {
         /**
@@ -149,44 +146,6 @@ export const RipePrice = {
         this.priceBind = this.ripeData.bind("price", this.onPriceChange);
     },
     methods: {
-        /**
-         * Configures the RIPE instance with the given brand,
-         * model, version and parts. The reload flag at true means that
-         * the configuration request comes after a first configuration,
-         * meaning the brand/model/version were changed. If this happens,
-         * the parts have to be resetted.
-         */
-        async configRipe(reload = false) {
-            this.loading = true;
-
-            try {
-                await this.ripeData.config(this.brand, this.model, {
-                    version: this.version,
-                    parts: reload ? null : this.parts,
-                    currency: this.currency.toUpperCase()
-                });
-            } catch (error) {
-                this.loading = false;
-                throw error;
-            }
-        },
-        /**
-         * Initializes RIPE instance if it does not exists and
-         * configures it with the given brand, model, version
-         * and parts. If a RIPE instance is provided, it will
-         * be used without further configuration.
-         */
-        async setupRipe() {
-            if (!this.ripeData) {
-                this.ripeData = new Ripe();
-            }
-
-            await this.configRipe();
-
-            if (!global.ripe) {
-                global.ripe = this.ripeData;
-            }
-        },
         onPriceChange(value) {
             this.price = value.total.price_final;
         }

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -9,6 +9,7 @@
 <script>
 import { Ripe } from "ripe-sdk";
 import { moneyMixin } from "../../../mixins";
+import { logicMixin, moneyMixin } from "../../../mixins";
 
 /**
  * The component that contains the price of the provided model,
@@ -17,6 +18,7 @@ import { moneyMixin } from "../../../mixins";
 export const RipePrice = {
     name: "ripe-price",
     mixins: [moneyMixin],
+    mixins: [logicMixin, moneyMixin],
     props: {
         /**
          * The brand of the model for which the price
@@ -82,6 +84,10 @@ export const RipePrice = {
              */
             loading: true,
             /**
+             * Parts of the model.
+             */
+            partsData: this.parts,
+            /**
              * Ripe SDK instance, which can be later initialized
              * if the given prop is not defined.
              */
@@ -89,6 +95,19 @@ export const RipePrice = {
         };
     },
     watch: {
+        parts: {
+            handler: async function(value, previous) {
+                if (this.equalParts(value, previous)) return;
+
+                this.partsData = value;
+                await this.configRipe();
+            }
+        },
+        partsData: {
+            handler: function(value) {
+                this.$emit("update:parts", value);
+            }
+        },
         currency: {
             handler: async function(value) {
                 await this.configRipe();

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -143,6 +143,10 @@ export const RipePrice = {
     created: async function() {
         await this.setupRipe();
 
+        this.ripeData.bind("parts", parts => {
+            this.partsData = parts;
+        });
+
         this.priceBind = this.ripeData.bind("price", this.onPriceChange);
     },
     methods: {

--- a/vue/mixins/index.js
+++ b/vue/mixins/index.js
@@ -1,1 +1,2 @@
 export * from "./money";
+export * from "./logic";

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -1,0 +1,45 @@
+import { Ripe } from "ripe-sdk";
+
+export const logicMixin = {
+    methods: {
+        equalParts(first, second) {
+            if (Boolean(first) !== Boolean(second)) {
+                return false;
+            }
+
+            if (!this._subsetCompare(first, second)) {
+                return false;
+            }
+
+            if (!this._subsetCompare(second, first)) {
+                return false;
+            }
+
+            return true;
+        },
+        _subsetCompare(base, reference) {
+            for (const name of Object.keys(base)) {
+                // retrieves the group information for the current
+                // name in iteration for both the base and the
+                // reference set values (to be compared)
+                const groupB = base[name];
+                const groupR = reference[name];
+
+                // if for a certain base group the corresponding
+                // group does not exist in the reference then the
+                // reference is considered to be invalid
+                if (!groupR) {
+                    return false;
+                }
+
+                // in case either the initials or the engraving is
+                // not matching then the subset is invalid
+                if (groupB.material !== groupR.material || groupB.color !== groupR.color) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+};

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -32,7 +32,7 @@ export const logicMixin = {
                 await this.ripeData.config(this.brand, this.model, {
                     version: this.version,
                     parts: this.parts,
-                    currency: this.currency?.toUpperCase()
+                    currency: this.currency ? this.currency.toUpperCase() : null
                 });
 
                 this.partsData = Object.assign({}, this.ripeData.parts);

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -58,22 +58,22 @@ export const logicMixin = {
         },
         _subsetCompare(base, reference) {
             for (const name of Object.keys(base)) {
-                // retrieves the group information for the current
+                // retrieves the part information for the current
                 // name in iteration for both the base and the
                 // reference set values (to be compared)
-                const groupB = base[name];
-                const groupR = reference[name];
+                const partB = base[name];
+                const partR = reference[name];
 
-                // if for a certain base group the corresponding
-                // group does not exist in the reference then the
+                // if for a certain base part the corresponding
+                // part does not exist in the reference then the
                 // reference is considered to be invalid
-                if (!groupR) {
+                if (!partR) {
                     return false;
                 }
 
                 // in case either the initials or the engraving is
                 // not matching then the subset is invalid
-                if (groupB.material !== groupR.material || groupB.color !== groupR.color) {
+                if (partB.material !== partR.material || partB.color !== partR.color) {
                     return false;
                 }
             }

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -2,6 +2,45 @@ import { Ripe } from "ripe-sdk";
 
 export const logicMixin = {
     methods: {
+        /**
+         * Initializes RIPE instance if it does not exists and
+         * configures it with the given brand, model, version
+         * and parts. If a RIPE instance is provided, it will
+         * be used without further configuration.
+         */
+        async setupRipe() {
+            if (!this.ripeData) {
+                this.ripeData = new Ripe();
+            }
+
+            await this.configRipe();
+
+            // in case the global RIPE instance is not set then
+            // updates it with the current one
+            if (!global.ripe) {
+                global.ripe = this.ripeData;
+            }
+        },
+        /**
+         * Configures the RIPE instance with the given brand,
+         * model, version and parts.
+         */
+        async configRipe() {
+            this.loading = true;
+
+            try {
+                await this.ripeData.config(this.brand, this.model, {
+                    version: this.version,
+                    parts: this.parts,
+                    currency: this.currency?.toUpperCase()
+                });
+
+                this.partsData = Object.assign({}, this.ripeData.parts);
+            } catch (error) {
+                this.loading = false;
+                throw error;
+            }
+        },
         equalParts(first, second) {
             if (Boolean(first) !== Boolean(second)) {
                 return false;

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -34,8 +34,6 @@ export const logicMixin = {
                     parts: this.parts,
                     currency: this.currency ? this.currency.toUpperCase() : null
                 });
-
-                this.partsData = Object.assign({}, this.ripeData.parts);
             } catch (error) {
                 this.loading = false;
                 throw error;


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | -- |
| Dependencies | -- |
| Decisions | All components that receive `parts` as props now have bi-directionality, meaning that any change to the parts made in the SDK will be communicated to the component's parent. <br><br> Refactor made to the setup of Ripe SDK, with the same functions being moved to a mixin. |
| Animated GIF | -- |
