### PR TITLE
Bump ripe-sdk version and remove polyfill from tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk-components-vue",
-    "version": "0.1.0",
+    "version": "0.0.1",
     "description": "RIPE SDK Components for Vue.js",
     "keywords": [
         "components",
@@ -58,7 +58,7 @@
     },
     "dependencies": {
         "loaders.css": "^0.1.2",
-        "ripe-sdk": "^1.12.1",
+        "ripe-sdk": "^1.14.1",
         "vue": "^2.6.12",
         "vue-global-events": "^1.2.1",
         "yonius": "^0.5.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ripe-sdk-components-vue",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "description": "RIPE SDK Components for Vue.js",
     "keywords": [
         "components",

--- a/vue/test/setup.js
+++ b/vue/test/setup.js
@@ -1,4 +1,3 @@
-require("@babel/polyfill");
 require("jsdom-global")(undefined, {
     url: "https://mock.ripe-pulse.platforme.com/"
 });


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Derived from https://github.com/ripe-tech/ripe-sdk-components-vue/pull/29#discussion_r507935804 |
| Dependencies | -- |
| Decisions | Bump ripe-sdk version and removed polyfill from test setup. |
| Animated GIF | -- |
