### PR TITLE
Update docs with recent changes

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -8,9 +8,10 @@ The configurator can receive the following parameters:
 
 | Prop            | Type      | Required | Description                                                                                                                                    |
 | --------------- | --------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| brand           | `String`  | `true`   | The brand of the model.                                                                                                                        |
-| model           | `String`  | `true`   | The name of the model.                                                                                                                         |
-| version         | `Number`  | `true`   | The version of the build.                                                                                                                      |
+| brand           | `String`  | `false`  | The brand of the model.                                                                                                                        |
+| model           | `String`  | `false`  | The name of the model.                                                                                                                         |
+| version         | `Number`  | `false`  | The version of the build.                                                                                                                      |
+| config          | `Boolean` | `false`  | Indicates that the component should apply the config internally on component initialization.                                                   |
 | parts           | `Object`  | `false`  | The model's customization.                                                                                                                     |
 | frame           | `String`  | `false`  | The name of the frame to be shown in the configurator. For example, frame `1` on `side` would be `side-1`, and a `top` frame would be `top-1`. |
 | size            | `Number`  | `false`  | The size (in pixels) of the configurator. If not defined, the configurator will use all the screen space available.                            |
@@ -145,9 +146,10 @@ The image can receive the following parameters:
 
 | Prop            | Type       | Required | Description                                                                                                                                                                                                |
 | --------------- | ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| brand           | `String`   | `true`   | The brand of the model.                                                                                                                                                                                    |
-| model           | `String`   | `true`   | The name of the model.                                                                                                                                                                                     |
-| version         | `Number`   | `true`   | The version of the build.                                                                                                                                                                                  |
+| brand           | `String`   | `false`  | The brand of the model.                                                                                                                                                                                    |
+| model           | `String`   | `false`  | The name of the model.                                                                                                                                                                                     |
+| version         | `Number`   | `false`  | The version of the build.                                                                                                                                                                                  |
+| config          | `Boolean`  | `false`  | Indicates that the component should apply the config internally on component initialization.                                                                                                               |
 | parts           | `Object`   | `false`  | The model's customization.                                                                                                                                                                                 |
 | frame           | `String`   | `false`  | The name of the frame to be shown in the image. For example, frame `1` on `side` would be `side-1`, and a `top` frame would be `top-1`.                                                                    |
 | size            | `Number`   | `false`  | The size (in pixels) of the image. If not defined, the image will use all the screen space available.                                                                                                      |
@@ -277,18 +279,19 @@ The price component `<ripe-price>` allows for the visualization of the price of 
 
 The component can receive the following parameters:
 
-| Prop     | Type     | Required | Description                                                                       |
-| -------- | -------- | -------- | --------------------------------------------------------------------------------- |
-| brand    | `String` | `true`   | The brand of the model.                                                           |
-| model    | `String` | `true`   | The name of the model.                                                            |
-| version  | `Number` | `true`   | The version of the build.                                                         |
-| parts    | `Object` | `false`  | The model's customization.                                                        |
-| currency | `String` | `true`   | The `ISO 4217` currency code in which the price will be displayed.                |
-| ripe     | `Object` | `false`  | Instance of Ripe SDK initialized, if not defined, a new one will be instantiated. |
+| Prop     | Type      | Required | Description                                                                                  |
+| -------- | --------- | -------- | -------------------------------------------------------------------------------------------- |
+| brand    | `String`  | `false`  | The brand of the model.                                                                      |
+| model    | `String`  | `false`  | The name of the model.                                                                       |
+| version  | `Number`  | `false`  | The version of the build.                                                                    |
+| config   | `Boolean` | `false`  | Indicates that the component should apply the config internally on component initialization. |
+| parts    | `Object`  | `false`  | The model's customization.                                                                   |
+| currency | `String`  | `true`   | The `ISO 4217` currency code in which the price will be displayed.                           |
+| ripe     | `Object`  | `false`  | Instance of Ripe SDK initialized, if not defined, a new one will be instantiated.            |
 
 An example of an instantiation and the correspondent view:
 
-```
+```html
 <ripe-price
     v-bind:brand="'dummy'"
     v-bind:model="'cube'"
@@ -301,7 +304,7 @@ An example of an instantiation and the correspondent view:
 
 Different customizations can result in different prices. Below is an example of a more expensive customization in both dollars and euros:
 
-```
+```html
 <ripe-price
     v-bind:brand="'dummy'"
     v-bind:model="'cube'"
@@ -327,7 +330,7 @@ Different customizations can result in different prices. Below is an example of 
 />
 ```
 
-```
+```html
 <ripe-price
     v-bind:brand="'dummy'"
     v-bind:model="'cube'"

--- a/vue/components/organisms/ripe-configurator/ripe-configurator.vue
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.vue
@@ -77,29 +77,21 @@ export const RipeConfigurator = {
          */
         brand: {
             type: String,
-            required: true
+            required: null
         },
         /**
          * The name of the model.
          */
         model: {
             type: String,
-            required: true
+            required: null
         },
         /**
          * The version of the build.
          */
         version: {
             type: Number,
-            required: true
-        },
-        /**
-         * The parts of the customized build as a dictionary mapping the
-         * name of the part to an object of material and color.
-         */
-        parts: {
-            type: Object,
-            default: null
+            required: null
         },
         /**
          * Indicates that the component should apply the config internally
@@ -108,6 +100,14 @@ export const RipeConfigurator = {
         config: {
             type: Boolean,
             default: true
+        },
+        /**
+         * The parts of the customized build as a dictionary mapping the
+         * name of the part to an object of material and color.
+         */
+        parts: {
+            type: Object,
+            default: null
         },
         /**
          * The name of the frame to be shown in the configurator using

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -34,18 +34,18 @@ export const RipePrice = {
             default: null
         },
         /**
-         * Indicates that the component should apply the config internally.
-         */
-        config: {
-            type: Boolean,
-            default: true
-        },
-        /**
          * The version of the build.
          */
         version: {
             type: Number,
             default: null
+        },
+        /**
+         * Indicates that the component should apply the config internally.
+         */
+        config: {
+            type: Boolean,
+            default: true
         },
         /**
          * The parts of the customized build as a dictionary mapping the


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to https://github.com/ripe-tech/ripe-sdk-components-vue/pull/32 |
| Dependencies | -- |
| Decisions | Updated docs with the new prop. Organized order in props so that there is the same order in all components. Made the brand/model/version optional in ripe-configurator, which is how it is in all the other components. |
| Animated GIF | -- |
