### PR TITLE
Fixed setInitials operation

### DIFF
--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -555,14 +555,19 @@ export const RipeImage = {
                 this.image?.setInitialsBuilder(value);
             }
         },
-        profiles: {
-            handler: function(value) {
-                this.setInitials(this.initials, value);
-            }
-        },
         initials: {
             handler: function(value) {
-                this.setInitials(value, this.profiles);
+                this.ripeData.setInitials(value, this.profiles || this.engraving);
+            }
+        },
+        engraving: {
+            handler: function(value) {
+                this.ripeData.setInitials(this.initials, value);
+            }
+        },
+        profiles: {
+            handler: function(value) {
+                this.ripeData.setInitials(this.initials, value);
             }
         },
         state: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Issue with `setInitials` method being removed in https://github.com/ripe-tech/ripe-sdk-components-vue/pull/38 |
| Dependencies | -- |
| Decisions | Fixed `setInitials` method call on `initials`, `engraving` and `profiles` watch. In this solution, profiles has bigger priority than `engraving`. I chose to be that way because `profiles` is a more detailed option than `engraving` |
| Animated GIF | -- |
