### PR TITLE
Fixed storybook not being in fullscreen

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,5 +5,9 @@ import { install as RipeSdkComponentsVue } from "../vue";
 
 import "./styles.css";
 
+export const parameters = {
+    layout: "fullscreen"
+};
+
 Vue.use(RipeSdkComponentsVue);
 Vue.component("global-events", GlobalEvents);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-components-vue/pull/420#issuecomment-757757548 |
| Dependencies | -- |
| Decisions | Fixed storybook width thus removing the always present scrollbar.<br><br>This issue ocurred because in storybook 6.0 there was an added `padding `of `1rem`. To fix this we needed to add the `fullscreen` param in  `.storybook/preview.js`. (See https://storybook.js.org/docs/vue/configure/story-layout). For more information about this problem, check [this github issue](https://github.com/storybookjs/storybook/issues/12109). |
| Animated GIF | **Before fix:**<br>![storybook_before](https://user-images.githubusercontent.com/22588915/103999777-3d93b780-5195-11eb-8785-5dbbe5bd6ac2.gif)<br><br>**After fix:**<br>![storybook_after](https://user-images.githubusercontent.com/22588915/104000029-96fbe680-5195-11eb-8e25-d26d182efd7b.gif) |