### PR TITLE
fix: shouldReset logic fix

### DIFF
--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -499,10 +499,14 @@ export const logicMixin = {
                     value.model !== previous.model ||
                     value.version !== previous.version) &&
                 (this.equalParts(value.parts, previous.parts) ||
-                    value.initials !== previous.initials ||
-                    value.engraving !== previous.engraving ||
-                    this.equalInitialsExtra(value.initialsExtra, previous.initialsExtra) ||
-                    this.equalInitialsExtra(value.initials_extra, previous.initials_extra))
+                    value.initials === previous.initials ||
+                    value.engraving === previous.engraving ||
+                    (value.initialsExtra &&
+                        previous.initialsExtra &&
+                        this.equalInitialsExtra(value.initialsExtra, previous.initialsExtra)) ||
+                    (value.initials_extra &&
+                        previous.initials_extra &&
+                        this.equalInitialsExtra(value.initials_extra, previous.initials_extra)))
             );
         },
         equalParts(first, second) {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When using the `structure` approach, the initials, engraving and parts provided when switching brand/models was not being implemented. This was due to the fact that the method `shouldReset` was wrong in its second check, instead of checking if initials/parts/initials_extra were different, it should be checking if they were equal, so they should be reseted, since they were from the previous model and are outdated. In this example, in the last switch to `dummy`, `parts`, `initials` and `engraving` were being provided but they were not applied: <br> https://user-images.githubusercontent.com/25725586/105071191-2b125b80-5a7c-11eb-9115-62fd3d1b368c.mp4|
| Dependencies | -- |
| Decisions | `shouldReset` modified to implement the correct logic. |
| Limitation | I noticed another limitation, but would like to discuss it before implementing it. Currently we are connecting the `parts` with the personalization (initials, engraving and initialsExtra). This means that when changing models, if we provide the parts but maintain the outdated personalization, the customization will update but the personalization will remain and not be deleted. <br> For example, below when changing to `sergio_rossi`, the parts are being provided but no override was made to the initials, they are maintained: <br>https://user-images.githubusercontent.com/25725586/105071691-d4f1e800-5a7c-11eb-97df-d0b8758e270a.mp4<br> In the example below in Animated GIF, no parts nor initials were overriden, and the reset works as expected:
| Animated GIF | With the fix: <br> https://user-images.githubusercontent.com/25725586/105071235-3796b400-5a7c-11eb-87d4-3a6a7bdf17b3.mp4|
