### PR TITLE
#2 Add configuring and price Vue emits

### DIFF
--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -30,11 +30,11 @@ export const RipePrice = {
         };
     },
     watch: {
-        error(value) {
-            this.$emit("error", value);
-        },
         price(value) {
             this.$emit("update:price", value);
+        },
+        error(value) {
+            this.$emit("error", value);
         }
     },
     computed: {

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -32,6 +32,9 @@ export const RipePrice = {
     watch: {
         error(value) {
             this.$emit("error", value);
+        },
+        price(value) {
+            this.$emit("update:price", value);
         }
     },
     computed: {

--- a/vue/components/organisms/ripe-price/ripe-price.vue
+++ b/vue/components/organisms/ripe-price/ripe-price.vue
@@ -31,7 +31,7 @@ export const RipePrice = {
     },
     watch: {
         price(value) {
-            this.$emit("update:price", value);
+            this.$emit("price", value);
         },
         error(value) {
             this.$emit("error", value);

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -327,6 +327,11 @@ export const logicMixin = {
                 else this.$emit("loaded");
             },
             immediate: true
+        },
+        configuring: {
+            handler: function(value) {
+                this.$emit("update:configuring", value);
+            }
         }
     },
     destroyed: function() {

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -330,7 +330,7 @@ export const logicMixin = {
         },
         configuring: {
             handler: function(value) {
-                this.$emit("update:configuring", value);
+                this.$emit("configuring", value);
             }
         }
     },


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch/issues/2 |
| Decisions | Add `configuring` and `price` Vue emits when their value changes. This is useful so it's possible for [button-price](https://github.com/ripe-tech/ripe-twitch-ui/blob/master/components/atoms/button-price/button-price.vue) to show loading state indicator when waiting for a price change event which can happen when the brand, model or other ripe config changes, triggering a new `configRipe()`. |
