### PR TITLE
fix: remove unnecessary state update

### DIFF
--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -491,9 +491,6 @@ export const RipeImage = {
         initialsBuilder(value) {
             this.image && this.image.setInitialsBuilder(value);
         },
-        async state(value) {
-            this.image && (await this.image.update(this.state));
-        },
         async imageProps(value) {
             this.image && (await this.image.updateOptions(value));
         }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch-ui/pull/35#issuecomment-767612448 |
| Dependencies | -- |
| Decisions | Removed unnecessary state update in `ripe-image`, which was causing the flickering. |
| Animated GIF | ![fix-ripe-image-bug](https://user-images.githubusercontent.com/25725586/105874655-bc417f00-5ff4-11eb-84e8-538a75f29cfc.gif)|

