### PR TITLE
#28 Remove workflow for node 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        node-version: [10, 11, 12, 13, 14]
+        node-version: [10, 12, 13, 14]
     runs-on: ubuntu-latest
     container: node:${{ matrix.node-version }}
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: trusty
 language: node_js
 node_js:
   - "10"
-  - "11"
   - "12"
   - "13"
   - "14"


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/peri-templating/issues/28#issuecomment-776878761 |
| Decisions | Remove node 11 from both the Github actions and the travis.yml files for all of the vue related repos. |