### PR TITLE
Fix storybook component search

### DIFF
--- a/vue/components/organisms/interaction-structure.stories.js
+++ b/vue/components/organisms/interaction-structure.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Interaction Structure", module)
     .addDecorator(withKnobs)
     .add("Interaction Structure", () => ({
         props: {

--- a/vue/components/organisms/interaction.stories.js
+++ b/vue/components/organisms/interaction.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, select } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/Interaction", module)
     .addDecorator(withKnobs)
     .add("Interaction", () => ({
         props: {

--- a/vue/components/organisms/ripe-configurator/ripe-configurator.stories.js
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/RipeConfigurator", module)
     .addDecorator(withKnobs)
     .add("RipeConfigurator", () => ({
         props: {

--- a/vue/components/organisms/ripe-image-zoom-hover/ripe-image-zoom-hover.stories.js
+++ b/vue/components/organisms/ripe-image-zoom-hover/ripe-image-zoom-hover.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/RipeImageZoomHover", module)
     .addDecorator(withKnobs)
     .add("RipeImageZoomHover", () => ({
         props: {

--- a/vue/components/organisms/ripe-image-zoom/ripe-image-zoom.stories.js
+++ b/vue/components/organisms/ripe-image-zoom/ripe-image-zoom.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/RipeImageZoom", module)
     .addDecorator(withKnobs)
     .add("RipeImageZoom", () => ({
         props: {

--- a/vue/components/organisms/ripe-image/ripe-image.stories.js
+++ b/vue/components/organisms/ripe-image/ripe-image.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number, boolean } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/RipeImage", module)
     .addDecorator(withKnobs)
     .add("RipeImage", () => ({
         props: {

--- a/vue/components/organisms/ripe-pickers/ripe-pickers.stories.js
+++ b/vue/components/organisms/ripe-pickers/ripe-pickers.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/RipePickers", module)
     .addDecorator(withKnobs)
     .add("RipePickers", () => ({
         data: function() {

--- a/vue/components/organisms/ripe-price/ripe-price.stories.js
+++ b/vue/components/organisms/ripe-price/ripe-price.stories.js
@@ -2,7 +2,7 @@ import { storiesOf } from "@storybook/vue";
 import { withKnobs, text, number } from "@storybook/addon-knobs";
 import { Ripe } from "ripe-sdk";
 
-storiesOf("Organisms", module)
+storiesOf("Components/Organisms/RipePrice", module)
     .addDecorator(withKnobs)
     .add("RipePrice", () => ({
         props: {


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | https://github.com/ripe-tech/ripe-twitch-ui/pull/74#issuecomment-771513137 <br> Fix to to pass the component title path in storiesOf() first argument and the story name in add() first argument. This fixes component search. Reference: https://github.com/storybookjs/storybook/blob/next/lib/core/docs/storiesOf.md#storiesof-api |

