### PR TITLE
feat: ripe-image emit loaded and error events

### DIFF
--- a/vue/components/organisms/ripe-configurator/ripe-configurator.vue
+++ b/vue/components/organisms/ripe-configurator/ripe-configurator.vue
@@ -283,26 +283,26 @@ export const RipeConfigurator = {
             this.loading = true;
         });
 
-        this.ripeData.bind("selected_part", part => {
+        this.onSelectedPartEvent = this.ripeData.bind("selected_part", part => {
             if (this.selectedPartData === part) return;
             this.selectedPartData = part;
         });
 
-        this.configurator.bind("changed_frame", frame => {
+        this.onChangedFrame = this.configurator.bind("changed_frame", frame => {
             this.frameData = frame;
         });
 
-        this.configurator.bind("loaded", () => {
+        this.onConfiguratorLoaded = this.configurator.bind("loaded", () => {
             const frame = `${this.configurator.view}-${this.configurator.position}`;
             this.frameData = frame;
             this.loading = false;
         });
 
-        this.configurator.bind("not_loaded", () => {
+        this.onConfiguratorNotLoaded = this.configurator.bind("not_loaded", () => {
             this.loading = false;
         });
 
-        this.configurator.bind("highlighted_part", part => {
+        this.onHighlightedPart = this.configurator.bind("highlighted_part", part => {
             if (this.highlightedPartData === part) return;
             this.highlightedPartData = part;
         });
@@ -320,7 +320,22 @@ export const RipeConfigurator = {
         }
     },
     destroyed: async function() {
+        if (this.configurator && this.onHighlightedPart) {
+            this.configurator.unbind("highlighted_part", this.onHighlightedPart);
+        }
+        if (this.configurator && this.onConfiguratorNotLoaded) {
+            this.configurator.unbind("not_loaded", this.onConfiguratorNotLoaded);
+        }
+        if (this.configurator && this.onConfiguratorLoaded) {
+            this.configurator.unbind("loaded", this.onConfiguratorLoaded);
+        }
+        if (this.configurator && this.onChangedFrame) {
+            this.configurator.unbind("changed_frame", this.onChangedFrame);
+        }
         if (this.configurator) await this.ripeData.unbindConfigurator(this.configurator);
+        if (this.onSelectedPartEvent && this.ripeData) {
+            this.ripeData.unbind("selected_part", this.onSelectedPartEvent);
+        }
         if (this.onPreConfigEvent && this.ripeData) {
             this.ripeData.unbind("pre_config", this.onPreConfigEvent);
         }

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -355,7 +355,7 @@ export const RipeImage = {
          * Line break, is optional and can have one of (normal and word_break).
          */
         lineBreaking: {
-            type: Boolean,
+            type: String,
             default: null
         },
         /**
@@ -551,12 +551,15 @@ export const RipeImage = {
             curve: this.curve
         });
 
+        this.image.bind("error", () => this.$emit("error"));
+
         // only updates if the SDK configuration is not empty
         if (this.ripeData.brand) await this.image.update(this.state);
     },
     methods: {
         onLoaded() {
             this.loading = false;
+            this.$emit("loaded");
         }
     },
     destroyed: async function() {

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -551,7 +551,7 @@ export const RipeImage = {
             curve: this.curve
         });
 
-        this.image.bind("error", () => this.$emit("error"));
+        this.onImageError = this.image.bind("error", () => this.onError());
 
         // only updates if the SDK configuration is not empty
         if (this.ripeData.brand) await this.image.update(this.state);
@@ -560,9 +560,13 @@ export const RipeImage = {
         onLoaded() {
             this.loading = false;
             this.$emit("loaded");
+        },
+        onError() {
+            this.$emit("error");
         }
     },
     destroyed: async function() {
+        if (this.image && this.onImageError) this.image.unbind("error", this.onImageError);
         if (this.image) await this.ripeData.unbindImage(this.image);
         this.image = null;
     }


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Originated from https://github.com/ripe-tech/ripe-twitch-ui/pull/91 |
| Dependencies | -- |
| Decisions | Added missing event propagation of `loaded` and `error` in `ripe-image`. <br> Tiny fix where lineBreaking was bool but its string. |
| Animated GIF | -- |
