### PR TITLE
Remove shouldReset logic

### DIFF
--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -175,15 +175,10 @@ export const logicMixin = {
                     model: value.model !== previous.model ? value.model : undefined,
                     version: value.version !== previous.version ? value.version : undefined,
                     currency: value.currency !== previous.currency ? value.currency : undefined,
-                    parts: value.parts,
-                    initials: value.initials !== previous.initials ? value.initials : undefined,
-                    engraving: value.engraving !== previous.engraving ? value.engraving : undefined,
-                    initialsExtra: !this.equalInitialsExtra(
-                        value.initialsExtra,
-                        previous.initialsExtra
-                    )
-                        ? value.initialsExtra
-                        : undefined
+                    parts: this.parts,
+                    initials: this.initials,
+                    engraving: this.engraving,
+                    initialsExtra: this.initialsExtra
                 });
             },
             deep: true
@@ -430,7 +425,7 @@ export const logicMixin = {
             brand = brand === undefined ? this.brandData : brand;
             model = model === undefined ? this.modelData : model;
             version = version === undefined ? this.versionData : version;
-            parts = parts === undefined ? this.parts || this.partsData : parts;
+            parts = parts === undefined ? this.partsData : parts;
             currency = currency === undefined ? this.currencyData : currency;
             initials = initials === undefined ? this.initialsData : initials;
             engraving = engraving === undefined ? this.engravingData : engraving;

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -169,8 +169,9 @@ export const logicMixin = {
     watch: {
         configOptions: {
             handler: async function(value, previous) {
-                if (!this.ripeData || !this.configData || !this.shouldConfigRipe(value, previous))
-                    { return; }
+                if (!this.ripeData || !this.configData || !this.shouldConfigRipe(value, previous)) {
+                    return;
+                }
 
                 // resets the personalization options if the model was changed
                 // but they stayed the same, which makes them invalid

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -536,16 +536,16 @@ export const logicMixin = {
                         this.equalInitialsExtra(value.initials_extra, previous.initials_extra)))
             );
         },
-        shouldConfigRipe(first, second) {
+        shouldConfigRipe(value, previous) {
             // checks to see if the model, brand,
             // version and currency changed
-            if (!first && !second) return false;
+            if (!value && !previous) return false;
 
             return (
-                first.brand !== second.brand ||
-                first.model !== second.model ||
-                first.version !== second.version ||
-                first.currency !== second.currency
+                value.brand !== previous.brand ||
+                value.model !== previous.model ||
+                value.version !== previous.version ||
+                value.currency !== previous.currency
             );
         },
         equalParts(first, second) {

--- a/vue/mixins/logic.js
+++ b/vue/mixins/logic.js
@@ -173,13 +173,13 @@ export const logicMixin = {
                     return;
                 }
 
-                // resets the personalization options if the model was changed
+                // resets the parts options if the model was changed
                 // but they stayed the same, which makes them invalid
                 if (this.shouldResetParts(value, previous)) {
                     value.parts = null;
                 }
 
-                // resets the parts options if the model was changed
+                // resets the personalization options if the model was changed
                 // but they stayed the same, which makes them invalid
                 if (this.shouldResetPersonalization(value, previous)) {
                     value.initials = "";
@@ -225,13 +225,13 @@ export const logicMixin = {
                 const equalCurrency = value.currency === previous.currency;
                 if (equalCurrency && equalStructure) return;
 
-                // resets the personalization options if the model was changed
+                // resets the parts options if the model was changed
                 // but they stayed the same, which makes them invalid
                 if (this.shouldResetParts(structure, previousStructure)) {
                     structure.parts = null;
                 }
 
-                // resets the parts options if the model was changed
+                // resets the personalization options if the model was changed
                 // but they stayed the same, which makes them invalid
                 if (this.shouldResetPersonalization(structure, previousStructure)) {
                     structure.initials = "";


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | When we change brand, model and parts, `ripe-configurator` will ignore passed parts when doing the new `config()`. |
| Decisions | - Remove `shouldReset` enforced logic and pass the responsability of having a proper config to the client using the component. |

**Note** Build is failing but it's also happening in the master so it's not related to this fix and the test fix should be done in a separate branch.
