### PR TITLE
fix: bump ripe-sdk and fix ripe-image 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     },
     "dependencies": {
         "loaders.css": "^0.1.2",
-        "ripe-sdk": "^1.23.0",
+        "ripe-sdk": "^2.6.0",
         "vue": "^2.6.12",
         "vue-global-events": "^1.2.1",
         "yonius": "^0.6.4"

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -496,8 +496,14 @@ export const RipeImage = {
         }
     },
     mounted: async function() {
-        this.ripeData.bind("ready", this.setupImage);
+        // if the SDK is defined but not yet ready
+        // it sets up the image only after the model
+        // config is loaded
+        if (this.ripeData) this.ripeData.bind("ready", this.setupImage);
         await this.setupRipe();
+
+        // sets up the image if the SDK instance is ready
+        if (this.ripeData.loadedConfig) await this.setupImage();
     },
     methods: {
         async setupImage() {
@@ -555,9 +561,7 @@ export const RipeImage = {
             });
 
             this.onImageError = this.image.bind("error", () => this.onError());
-
-            // only updates if the SDK configuration is not empty
-            if (this.ripeData.brand) await this.image.update(this.state);
+            await this.image.update(this.state);
         },
         onLoaded() {
             this.loading = false;

--- a/vue/components/organisms/ripe-image/ripe-image.vue
+++ b/vue/components/organisms/ripe-image/ripe-image.vue
@@ -496,67 +496,69 @@ export const RipeImage = {
         }
     },
     mounted: async function() {
+        this.ripeData.bind("ready", this.setupImage);
         await this.setupRipe();
-
-        this.image = this.ripeData.bindImage(this.$refs.image, {
-            frame: this.frame,
-            size: this.size || undefined,
-            format: this.format,
-            crop: this.crop,
-            showInitials: this.showInitials,
-            initialsGroup: this.initialsGroup,
-            initialsBuilder: this.initialsBuilder,
-            rotation: this.rotation,
-            flip: this.flip,
-            mirror: this.mirror,
-            boundingBox: this.boundingBox,
-            algorithm: this.algorithm,
-            background: this.background,
-            engine: this.engine,
-            initialsX: this.initialsX,
-            initialsY: this.initialsY,
-            initialsWidth: this.initialsWidth,
-            initialsHeight: this.initialsHeight,
-            initialsViewport: this.initialsViewport,
-            initialsColor: this.initialsColor,
-            initialsOpacity: this.initialsOpacity,
-            initialsAlign: this.initialsAlign,
-            initialsVertical: this.initialsVertical,
-            initialsEmbossing: this.initialsEmbossing,
-            initialsRotation: this.initialsRotation,
-            initialsZindex: this.initialsZindex,
-            initialsAlgorithm: this.initialsAlgorithm,
-            initialsBlendColor: this.initialsBlendColor,
-            initialsPattern: this.initialsPattern,
-            initialsTexture: this.initialsTexture,
-            initialsExclusion: this.initialsExclusion,
-            initialsInclusion: this.initialsInclusion,
-            initialsImageRotation: this.initialsImageRotation,
-            initialsImageFlip: this.initialsImageFlip,
-            initialsImageMirror: this.initialsImageMirror,
-            debug: this.debug,
-            fontFamily: this.fontFamily,
-            fontWeight: this.fontWeight,
-            fontSize: this.fontSize,
-            fontSpacing: this.fontSpacing,
-            fontTrim: this.fontTrim,
-            fontMask: this.fontMask,
-            fontMode: this.fontMode,
-            lineHeight: this.lineHeight,
-            lineBreaking: this.lineBreaking,
-            shadow: this.shadow,
-            shadowColor: this.shadowColor,
-            shadowOffset: this.shadowOffset,
-            offsets: this.offsets,
-            curve: this.curve
-        });
-
-        this.onImageError = this.image.bind("error", () => this.onError());
-
-        // only updates if the SDK configuration is not empty
-        if (this.ripeData.brand) await this.image.update(this.state);
     },
     methods: {
+        async setupImage() {
+            this.image = this.ripeData.bindImage(this.$refs.image, {
+                frame: this.frame,
+                size: this.size || undefined,
+                format: this.format,
+                crop: this.crop,
+                showInitials: this.showInitials,
+                initialsGroup: this.initialsGroup,
+                initialsBuilder: this.initialsBuilder,
+                rotation: this.rotation,
+                flip: this.flip,
+                mirror: this.mirror,
+                boundingBox: this.boundingBox,
+                algorithm: this.algorithm,
+                background: this.background,
+                engine: this.engine,
+                initialsX: this.initialsX,
+                initialsY: this.initialsY,
+                initialsWidth: this.initialsWidth,
+                initialsHeight: this.initialsHeight,
+                initialsViewport: this.initialsViewport,
+                initialsColor: this.initialsColor,
+                initialsOpacity: this.initialsOpacity,
+                initialsAlign: this.initialsAlign,
+                initialsVertical: this.initialsVertical,
+                initialsEmbossing: this.initialsEmbossing,
+                initialsRotation: this.initialsRotation,
+                initialsZindex: this.initialsZindex,
+                initialsAlgorithm: this.initialsAlgorithm,
+                initialsBlendColor: this.initialsBlendColor,
+                initialsPattern: this.initialsPattern,
+                initialsTexture: this.initialsTexture,
+                initialsExclusion: this.initialsExclusion,
+                initialsInclusion: this.initialsInclusion,
+                initialsImageRotation: this.initialsImageRotation,
+                initialsImageFlip: this.initialsImageFlip,
+                initialsImageMirror: this.initialsImageMirror,
+                debug: this.debug,
+                fontFamily: this.fontFamily,
+                fontWeight: this.fontWeight,
+                fontSize: this.fontSize,
+                fontSpacing: this.fontSpacing,
+                fontTrim: this.fontTrim,
+                fontMask: this.fontMask,
+                fontMode: this.fontMode,
+                lineHeight: this.lineHeight,
+                lineBreaking: this.lineBreaking,
+                shadow: this.shadow,
+                shadowColor: this.shadowColor,
+                shadowOffset: this.shadowOffset,
+                offsets: this.offsets,
+                curve: this.curve
+            });
+
+            this.onImageError = this.image.bind("error", () => this.onError());
+
+            // only updates if the SDK configuration is not empty
+            if (this.ripeData.brand) await this.image.update(this.state);
+        },
         onLoaded() {
             this.loading = false;
             this.$emit("loaded");

--- a/vue/test/components/ripe-pickers/ripe-pickers.test.js
+++ b/vue/test/components/ripe-pickers/ripe-pickers.test.js
@@ -100,6 +100,7 @@ describe("RipePickers", function() {
         await ripeInstance.isReady();
         ripeInstance.setChoices(_choices);
         await component.vm.$forceUpdate();
+        await component.vm.$nextTick();
         assert.strictEqual(component.find(".select-parts").exists(), true);
         assert.strictEqual(component.find(".select-materials").exists(), true);
         assert.strictEqual(component.find(".select-colors").exists(), true);
@@ -117,7 +118,7 @@ describe("RipePickers", function() {
 
         await ripeInstance.isReady();
         ripeInstance.setChoices(_choices);
-        await component.vm.$forceUpdate();
+        await component.vm.$nextTick();
         await component.vm.onSelectPartChange("side");
         assert.strictEqual(component.find(".select-parts").findAll("option").length, 4);
         assert.strictEqual(component.find(".select-materials").findAll("option").length, 4);

--- a/vue/test/components/ripe-pickers/ripe-pickers.test.js
+++ b/vue/test/components/ripe-pickers/ripe-pickers.test.js
@@ -98,7 +98,7 @@ describe("RipePickers", function() {
         assert.strictEqual(component.emitted("loading").length, 1);
 
         await ripeInstance.isReady();
-        await ripeInstance.trigger("choices", _choices);
+        ripeInstance.setChoices(_choices);
         await component.vm.$forceUpdate();
         assert.strictEqual(component.find(".select-parts").exists(), true);
         assert.strictEqual(component.find(".select-materials").exists(), true);
@@ -116,7 +116,7 @@ describe("RipePickers", function() {
         const component = await base.getComponent("RipePickers", { props: { ripe: ripeInstance } });
 
         await ripeInstance.isReady();
-        await ripeInstance.trigger("choices", _choices);
+        ripeInstance.setChoices(_choices);
         await component.vm.$forceUpdate();
         await component.vm.onSelectPartChange("side");
         assert.strictEqual(component.find(".select-parts").findAll("option").length, 4);

--- a/vue/test/components/ripe-pickers/ripe-pickers.test.js
+++ b/vue/test/components/ripe-pickers/ripe-pickers.test.js
@@ -99,6 +99,7 @@ describe("RipePickers", function() {
 
         await ripeInstance.isReady();
         ripeInstance.setChoices(_choices);
+        await component.vm.$nextTick();
         await component.vm.$forceUpdate();
         await component.vm.$nextTick();
         assert.strictEqual(component.find(".select-parts").exists(), true);
@@ -118,6 +119,7 @@ describe("RipePickers", function() {
 
         await ripeInstance.isReady();
         ripeInstance.setChoices(_choices);
+        await component.vm.$forceUpdate();
         await component.vm.$nextTick();
         await component.vm.onSelectPartChange("side");
         assert.strictEqual(component.find(".select-parts").findAll("option").length, 4);


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Changes related to SDK initial, which requires the loaded config. This resulted in an error when construction `ripe-image` when the SDK was not yet ready.<br>![image](https://user-images.githubusercontent.com/25725586/131659281-455d428f-e915-40e2-b183-926c28a49c5d.png) |
| Dependencies | -- |
| Decisions | - Bumped SDK version to most recent<br>- Fixed problem of loadedConfig is null by only binding the image after the SDK is ready. |
| Animated GIF | -- |
